### PR TITLE
Fix blank page on deployment, update title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Jasvir Singh Dhillon</title>
   </head>
   <body>
     <div id="root"></div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/jasvir340.github.io/',
+  // Use root base so assets resolve correctly when served from a
+  // custom domain. A non-root base caused blank pages because the
+  // generated asset URLs did not match the deployed location.
+  base: '/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- set Vite base URL to `/` so assets resolve correctly for the `jasvir.in` domain
- update document title

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857d3c6157883309073a32b72bc3181