### PR TITLE
Add categories to skills display

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -16,6 +16,15 @@ h1 {
   color: #003366;
 }
 
+.category-section {
+  margin-bottom: 2rem;
+}
+
+.category-section h2 {
+  margin-bottom: 1rem;
+  color: #004488;
+}
+
 .icon-grid {
   display: flex;
   flex-wrap: wrap;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,55 +21,115 @@ import {
 } from 'react-icons/si'
 
 function App() {
-  const skills = [
-    { label: 'Java', icon: <FaJava /> },
-    { label: 'Python', icon: <SiPython /> },
-    { label: 'Spring', icon: <SiSpring /> },
-    { label: 'Quarkus', icon: <SiQuarkus /> },
-    { label: 'FastAPI', icon: <SiFastapi /> },
-    { label: 'MySQL', icon: <SiMysql /> },
-    { label: 'PostgreSQL', icon: <SiPostgresql /> },
-    { label: 'MongoDB', icon: <SiMongodb /> },
-    { label: 'Cassandra', icon: <SiApachecassandra /> },
-    { label: 'Qdrant', icon: <FaQuestion /> },
-    { label: 'MongoEngine', icon: <FaQuestion /> },
-    { label: 'Hibernate', icon: <SiHibernate /> },
-    { label: 'Microsoft Autogen', icon: <FaQuestion /> },
-    { label: 'AG2', icon: <FaQuestion /> },
-    { label: 'LangChain', icon: <SiLangchain /> },
-    { label: 'LangGraph', icon: <FaQuestion /> },
-    { label: 'Agno', icon: <FaQuestion /> },
-    { label: 'CrewAI', icon: <FaQuestion /> },
-    { label: 'Langfuse', icon: <FaQuestion /> },
-    { label: 'Promptflow', icon: <FaQuestion /> },
-    { label: 'Microsoft Evaluation Framework', icon: <FaQuestion /> },
-    { label: 'Google Evaluation Framework', icon: <FaQuestion /> },
-    { label: 'LLM', icon: <FaQuestion /> },
-    { label: 'RAG', icon: <FaQuestion /> },
-    { label: 'Kafka', icon: <SiApachekafka /> },
-    { label: 'Temporal', icon: <SiTemporal /> },
-    { label: 'Avro', icon: <FaQuestion /> },
-    { label: 'ProtoBuf', icon: <FaQuestion /> },
-    { label: 'JUnit', icon: <SiJunit5 /> },
-    { label: 'JMeter', icon: <SiApachejmeter /> },
-    { label: 'Grafana', icon: <SiGrafana /> },
-    { label: 'Scalyr', icon: <FaQuestion /> },
-    { label: 'Oracle Flight Recorder', icon: <FaQuestion /> },
-    { label: 'Docker', icon: <SiDocker /> },
-    { label: 'Git', icon: <SiGit /> }
+  const categorizedSkills = [
+    {
+      category: 'Programming Languages',
+      skills: [
+        { label: 'Java', icon: <FaJava /> },
+        { label: 'Python', icon: <SiPython /> }
+      ],
+    },
+    {
+      category: 'Frameworks and Libraries',
+      skills: [
+        { label: 'Spring', icon: <SiSpring /> },
+        { label: 'Quarkus', icon: <SiQuarkus /> },
+        { label: 'FastAPI', icon: <SiFastapi /> },
+        { label: 'Hibernate', icon: <SiHibernate /> },
+        { label: 'MongoEngine', icon: <FaQuestion /> },
+      ],
+    },
+    {
+      category: 'Databases / Storage',
+      skills: [
+        { label: 'MySQL', icon: <SiMysql /> },
+        { label: 'PostgreSQL', icon: <SiPostgresql /> },
+        { label: 'MongoDB', icon: <SiMongodb /> },
+        { label: 'Cassandra', icon: <SiApachecassandra /> },
+        { label: 'Qdrant', icon: <FaQuestion /> },
+      ],
+    },
+    {
+      category: 'AI Frameworks / Agents',
+      skills: [
+        { label: 'Microsoft Autogen', icon: <FaQuestion /> },
+        { label: 'AG2', icon: <FaQuestion /> },
+        { label: 'LangChain', icon: <SiLangchain /> },
+        { label: 'LangGraph', icon: <FaQuestion /> },
+        { label: 'Agno', icon: <FaQuestion /> },
+        { label: 'CrewAI', icon: <FaQuestion /> },
+        { label: 'Langfuse', icon: <FaQuestion /> },
+        { label: 'Promptflow', icon: <FaQuestion /> },
+      ],
+    },
+    {
+      category: 'AI Evaluation Frameworks',
+      skills: [
+        { label: 'Microsoft Evaluation Framework', icon: <FaQuestion /> },
+        { label: 'Google Evaluation Framework', icon: <FaQuestion /> },
+      ],
+    },
+    {
+      category: 'AI Concepts',
+      skills: [
+        { label: 'LLM', icon: <FaQuestion /> },
+        { label: 'RAG', icon: <FaQuestion /> },
+      ],
+    },
+    {
+      category: 'Messaging / Workflow',
+      skills: [
+        { label: 'Kafka', icon: <SiApachekafka /> },
+        { label: 'Temporal', icon: <SiTemporal /> },
+      ],
+    },
+    {
+      category: 'Data Serialization Formats',
+      skills: [
+        { label: 'Avro', icon: <FaQuestion /> },
+        { label: 'ProtoBuf', icon: <FaQuestion /> },
+      ],
+    },
+    {
+      category: 'Testing Tools',
+      skills: [
+        { label: 'JUnit', icon: <SiJunit5 /> },
+        { label: 'JMeter', icon: <SiApachejmeter /> },
+      ],
+    },
+    {
+      category: 'Observability and Monitoring',
+      skills: [
+        { label: 'Grafana', icon: <SiGrafana /> },
+        { label: 'Scalyr', icon: <FaQuestion /> },
+        { label: 'Oracle Flight Recorder', icon: <FaQuestion /> },
+      ],
+    },
+    {
+      category: 'DevOps and Version Control',
+      skills: [
+        { label: 'Docker', icon: <SiDocker /> },
+        { label: 'Git', icon: <SiGit /> },
+      ],
+    },
   ]
 
   return (
     <div className="container">
       <h1>Jasvir Singh Dhillon</h1>
-      <div className="icon-grid">
-        {skills.map((skill) => (
-          <div className="droplet" key={skill.label}>
-            {skill.icon}
-            <span>{skill.label}</span>
+      {categorizedSkills.map((section) => (
+        <div className="category-section" key={section.category}>
+          <h2>{section.category}</h2>
+          <div className="icon-grid">
+            {section.skills.map((skill) => (
+              <div className="droplet" key={skill.label}>
+                {skill.icon}
+                <span>{skill.label}</span>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
+        </div>
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- group skills by category in `App.jsx`
- display each category as a section with its skills
- style category sections in `App.css`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857e3b6cfb48330bd7c2fb038aaabac