### PR TITLE
Make style more Instagram-like

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,16 +4,20 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: #ffffff;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(10px);
   padding: 2rem;
   text-align: center;
-  font-family: Arial, sans-serif;
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
 }
 
 h1 {
   font-size: 2.5rem;
   margin-bottom: 2rem;
-  color: #003366;
+  background: linear-gradient(45deg, #f09433, #e6683c, #dc2743, #cc2366, #bc1888);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .contact {
@@ -21,8 +25,9 @@ h1 {
 }
 
 .contact a {
-  color: #0066cc;
+  color: #fff;
   text-decoration: none;
+  font-weight: bold;
 }
 
 .contact a:hover {
@@ -35,7 +40,7 @@ h1 {
 
 .category-section h2 {
   margin-bottom: 1rem;
-  color: #004488;
+  color: #fff;
 }
 
 .icon-grid {
@@ -51,7 +56,7 @@ h1 {
   width: 90px;
   height: 90px;
   border-radius: 50%;
-  background: #f7f7f7;
+  background: radial-gradient(circle at 30% 107%, #fdf497 0%, #fdf497 5%, #fd5949 45%, #d6249f 60%, #285AEB 90%);
   backdrop-filter: blur(5px);
   box-shadow:
     inset 0 2px 6px rgba(255, 255, 255, 0.8),
@@ -60,7 +65,7 @@ h1 {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  color: #002244;
+  color: #fff;
   transition: transform 0.2s;
 }
 
@@ -71,6 +76,7 @@ h1 {
 .droplet span {
   margin-top: 0.3rem;
   font-size: 0.65rem;
+  color: #fff;
 }
 
 .droplet svg {

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
 body {
   margin: 0;
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+  background: linear-gradient(135deg, #f9ce34, #ee2a7b, #6228d7);
+  min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- add gradient background and modern fonts
- style main container with translucency and gradient text
- update colors of droplet icons to match Instagram

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f01b5ae2083309561049650d4c59d