### PR TITLE
Fix header visibility and update lightning colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,11 @@
         width: 100%;
         height: 100%;
         pointer-events: none;
+        z-index: 0;
+      }
+      .content {
+        position: relative;
+        z-index: 1;
       }
     </style>
   </head>
@@ -64,7 +69,11 @@
       function drawLightning(x1, y1, x2, y2) {
         const segments = 20;
         const amplitude = 20;
-        ctx.strokeStyle = 'rgba(173,216,255,0.8)';
+        const gradient = ctx.createLinearGradient(x1, y1, x2, y2);
+        gradient.addColorStop(0, 'blue');
+        gradient.addColorStop(0.5, 'yellow');
+        gradient.addColorStop(1, 'red');
+        ctx.strokeStyle = gradient;
         ctx.lineWidth = 2;
         ctx.shadowColor = '#9df';
         ctx.shadowBlur = 15;


### PR DESCRIPTION
## Summary
- keep lightning canvas behind text so header stays visible
- draw lightning with blue, yellow and red gradient

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68600f5e6cb883308bacbd6332e170dc